### PR TITLE
Fix HTML5 validation

### DIFF
--- a/contact-form/index.php
+++ b/contact-form/index.php
@@ -83,7 +83,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <?php endif; ?>
 
     <div class="col-md-6 col-md-offset-3">
-        <form action="<?php echo $_SERVER['REQUEST_URI']; ?>" enctype="application/x-www-form-urlencoded;" id="contact-form" class="form-horizontal" role="form" method="post">
+        <form action="<?php echo $_SERVER['REQUEST_URI']; ?>" enctype="application/x-www-form-urlencoded" id="contact-form" class="form-horizontal" method="post">
             <div class="form-group">
                 <label for="form-name" class="col-lg-2 control-label"><?php echo $config->get('fields.name'); ?></label>
                 <div class="col-lg-10">


### PR DESCRIPTION
Hello,

Recently I ran the form HTML through the W3C HTML validator, and it came up with:
- Invalid enctype attribute (a `;` was included)
- Warning about `role="form"`, because it is placed on the `form` element, and thus considered redundant. 

This pull request fixes both issues.